### PR TITLE
ハッシュタグモデルの実装

### DIFF
--- a/Gitagram.xcodeproj/project.pbxproj
+++ b/Gitagram.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		10D526252C243731004E66EA /* HashTagResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10D526242C243726004E66EA /* HashTagResponse.swift */; };
 		10D526272C2437F0004E66EA /* HashTagClientProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10D526262C2437EF004E66EA /* HashTagClientProtocol.swift */; };
 		10D5262A2C243867004E66EA /* HashTagClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10D526292C243864004E66EA /* HashTagClient.swift */; };
+		10D5262C2C2439C1004E66EA /* HashTagRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10D5262B2C24398A004E66EA /* HashTagRepositoryProtocol.swift */; };
 		23B6E52D2BE73C1D0049200B /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23B6E52C2BE73C1D0049200B /* ContentView.swift */; };
 		722E84052BE735EA007163D4 /* CardStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 722E83F82BE735EA007163D4 /* CardStackView.swift */; };
 		722E84062BE735EA007163D4 /* CardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 722E83F92BE735EA007163D4 /* CardView.swift */; };
@@ -101,6 +102,7 @@
 		10D526242C243726004E66EA /* HashTagResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HashTagResponse.swift; sourceTree = "<group>"; };
 		10D526262C2437EF004E66EA /* HashTagClientProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HashTagClientProtocol.swift; sourceTree = "<group>"; };
 		10D526292C243864004E66EA /* HashTagClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HashTagClient.swift; sourceTree = "<group>"; };
+		10D5262B2C24398A004E66EA /* HashTagRepositoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HashTagRepositoryProtocol.swift; sourceTree = "<group>"; };
 		23B6E52C2BE73C1D0049200B /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		23B6E52E2BE7540F0049200B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		722E83F82BE735EA007163D4 /* CardStackView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardStackView.swift; sourceTree = "<group>"; };
@@ -435,6 +437,7 @@
 		722E845E2BE7365F007163D4 /* Protocol */ = {
 			isa = PBXGroup;
 			children = (
+				10D5262B2C24398A004E66EA /* HashTagRepositoryProtocol.swift */,
 				722E84592BE7365F007163D4 /* DeveloperImageRepositoryProtocol.swift */,
 				722E845A2BE7365F007163D4 /* DeveloperRepositoryProtocol.swift */,
 				722E845B2BE7365F007163D4 /* ProductImageRepositoryProtocol.swift */,
@@ -633,6 +636,7 @@
 				722E840C2BE735EA007163D4 /* MatchingView.swift in Sources */,
 				722E847B2BE7365F007163D4 /* ProductImageRepositoryProtocol.swift in Sources */,
 				722E848A2BE73A2A007163D4 /* AccountView.swift in Sources */,
+				10D5262C2C2439C1004E66EA /* HashTagRepositoryProtocol.swift in Sources */,
 				722E84772BE7365F007163D4 /* GetProductListUseCase.swift in Sources */,
 				722E841B2BE7360C007163D4 /* InputFormView.swift in Sources */,
 				722E840B2BE735EA007163D4 /* SizeConstants.swift in Sources */,

--- a/Gitagram.xcodeproj/project.pbxproj
+++ b/Gitagram.xcodeproj/project.pbxproj
@@ -32,6 +32,8 @@
 		10D5262A2C243867004E66EA /* HashTagClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10D526292C243864004E66EA /* HashTagClient.swift */; };
 		10D5262C2C2439C1004E66EA /* HashTagRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10D5262B2C24398A004E66EA /* HashTagRepositoryProtocol.swift */; };
 		10D5262F2C243A2E004E66EA /* HashTagRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10D5262E2C243A28004E66EA /* HashTagRepository.swift */; };
+		10D526312C243CB6004E66EA /* TagProductClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10D526302C243CAE004E66EA /* TagProductClient.swift */; };
+		10D526332C243CE6004E66EA /* HashTagProductClientProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10D526322C243CE5004E66EA /* HashTagProductClientProtocol.swift */; };
 		23B6E52D2BE73C1D0049200B /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23B6E52C2BE73C1D0049200B /* ContentView.swift */; };
 		722E84052BE735EA007163D4 /* CardStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 722E83F82BE735EA007163D4 /* CardStackView.swift */; };
 		722E84062BE735EA007163D4 /* CardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 722E83F92BE735EA007163D4 /* CardView.swift */; };
@@ -105,6 +107,8 @@
 		10D526292C243864004E66EA /* HashTagClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HashTagClient.swift; sourceTree = "<group>"; };
 		10D5262B2C24398A004E66EA /* HashTagRepositoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HashTagRepositoryProtocol.swift; sourceTree = "<group>"; };
 		10D5262E2C243A28004E66EA /* HashTagRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HashTagRepository.swift; sourceTree = "<group>"; };
+		10D526302C243CAE004E66EA /* TagProductClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagProductClient.swift; sourceTree = "<group>"; };
+		10D526322C243CE5004E66EA /* HashTagProductClientProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HashTagProductClientProtocol.swift; sourceTree = "<group>"; };
 		23B6E52C2BE73C1D0049200B /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		23B6E52E2BE7540F0049200B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		722E83F82BE735EA007163D4 /* CardStackView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardStackView.swift; sourceTree = "<group>"; };
@@ -264,6 +268,7 @@
 		10D526212C243693004E66EA /* HashTag */ = {
 			isa = PBXGroup;
 			children = (
+				10D526302C243CAE004E66EA /* TagProductClient.swift */,
 				10D526292C243864004E66EA /* HashTagClient.swift */,
 			);
 			path = HashTag;
@@ -448,6 +453,7 @@
 		722E845E2BE7365F007163D4 /* Protocol */ = {
 			isa = PBXGroup;
 			children = (
+				10D526322C243CE5004E66EA /* HashTagProductClientProtocol.swift */,
 				10D5262B2C24398A004E66EA /* HashTagRepositoryProtocol.swift */,
 				722E84592BE7365F007163D4 /* DeveloperImageRepositoryProtocol.swift */,
 				722E845A2BE7365F007163D4 /* DeveloperRepositoryProtocol.swift */,
@@ -634,6 +640,7 @@
 				722E84142BE73601007163D4 /* ImagePickerView.swift in Sources */,
 				10261B0A2BE94695007D1606 /* AccountViewModel.swift in Sources */,
 				722E846B2BE7365F007163D4 /* ProductImageRepository.swift in Sources */,
+				10D526332C243CE6004E66EA /* HashTagProductClientProtocol.swift in Sources */,
 				10261B072BE94520007D1606 /* KiraKiraView.swift in Sources */,
 				722E847E2BE7365F007163D4 /* TakeScreenShotUseCase.swift in Sources */,
 				722E84642BE7365F007163D4 /* DeveloperClient.swift in Sources */,
@@ -649,6 +656,7 @@
 				722E848A2BE73A2A007163D4 /* AccountView.swift in Sources */,
 				10D5262C2C2439C1004E66EA /* HashTagRepositoryProtocol.swift in Sources */,
 				722E84772BE7365F007163D4 /* GetProductListUseCase.swift in Sources */,
+				10D526312C243CB6004E66EA /* TagProductClient.swift in Sources */,
 				722E841B2BE7360C007163D4 /* InputFormView.swift in Sources */,
 				722E840B2BE735EA007163D4 /* SizeConstants.swift in Sources */,
 				10D5262F2C243A2E004E66EA /* HashTagRepository.swift in Sources */,

--- a/Gitagram.xcodeproj/project.pbxproj
+++ b/Gitagram.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		10502C6E2C1E850700097342 /* HashTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10502C6D2C1E850700097342 /* HashTag.swift */; };
 		10D526252C243731004E66EA /* HashTagResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10D526242C243726004E66EA /* HashTagResponse.swift */; };
 		10D526272C2437F0004E66EA /* HashTagClientProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10D526262C2437EF004E66EA /* HashTagClientProtocol.swift */; };
+		10D5262A2C243867004E66EA /* HashTagClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10D526292C243864004E66EA /* HashTagClient.swift */; };
 		23B6E52D2BE73C1D0049200B /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23B6E52C2BE73C1D0049200B /* ContentView.swift */; };
 		722E84052BE735EA007163D4 /* CardStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 722E83F82BE735EA007163D4 /* CardStackView.swift */; };
 		722E84062BE735EA007163D4 /* CardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 722E83F92BE735EA007163D4 /* CardView.swift */; };
@@ -99,6 +100,7 @@
 		10502C6D2C1E850700097342 /* HashTag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HashTag.swift; sourceTree = "<group>"; };
 		10D526242C243726004E66EA /* HashTagResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HashTagResponse.swift; sourceTree = "<group>"; };
 		10D526262C2437EF004E66EA /* HashTagClientProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HashTagClientProtocol.swift; sourceTree = "<group>"; };
+		10D526292C243864004E66EA /* HashTagClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HashTagClient.swift; sourceTree = "<group>"; };
 		23B6E52C2BE73C1D0049200B /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		23B6E52E2BE7540F0049200B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		722E83F82BE735EA007163D4 /* CardStackView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardStackView.swift; sourceTree = "<group>"; };
@@ -258,6 +260,7 @@
 		10D526212C243693004E66EA /* HashTag */ = {
 			isa = PBXGroup;
 			children = (
+				10D526292C243864004E66EA /* HashTagClient.swift */,
 			);
 			path = HashTag;
 			sourceTree = "<group>";
@@ -639,6 +642,7 @@
 				722E84782BE7365F007163D4 /* PostProductUseCase.swift in Sources */,
 				722E84722BE7365F007163D4 /* CreateDeveloperUseCase.swift in Sources */,
 				722E846A2BE7365F007163D4 /* DeveloperRepository.swift in Sources */,
+				10D5262A2C243867004E66EA /* HashTagClient.swift in Sources */,
 				722E848B2BE73A2A007163D4 /* KiraKiraViewModel.swift in Sources */,
 				722E84742BE7365F007163D4 /* GetDeveloperUseCase.swift in Sources */,
 				722E84712BE7365F007163D4 /* RepositoryDI.swift in Sources */,

--- a/Gitagram.xcodeproj/project.pbxproj
+++ b/Gitagram.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		10472EEE2BDFAFBD00C179F8 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 10472EED2BDFAFBD00C179F8 /* Preview Assets.xcassets */; };
 		10502C6E2C1E850700097342 /* HashTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10502C6D2C1E850700097342 /* HashTag.swift */; };
 		10D526252C243731004E66EA /* HashTagResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10D526242C243726004E66EA /* HashTagResponse.swift */; };
+		10D526272C2437F0004E66EA /* HashTagClientProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10D526262C2437EF004E66EA /* HashTagClientProtocol.swift */; };
 		23B6E52D2BE73C1D0049200B /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23B6E52C2BE73C1D0049200B /* ContentView.swift */; };
 		722E84052BE735EA007163D4 /* CardStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 722E83F82BE735EA007163D4 /* CardStackView.swift */; };
 		722E84062BE735EA007163D4 /* CardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 722E83F92BE735EA007163D4 /* CardView.swift */; };
@@ -97,6 +98,7 @@
 		10472EED2BDFAFBD00C179F8 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		10502C6D2C1E850700097342 /* HashTag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HashTag.swift; sourceTree = "<group>"; };
 		10D526242C243726004E66EA /* HashTagResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HashTagResponse.swift; sourceTree = "<group>"; };
+		10D526262C2437EF004E66EA /* HashTagClientProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HashTagClientProtocol.swift; sourceTree = "<group>"; };
 		23B6E52C2BE73C1D0049200B /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		23B6E52E2BE7540F0049200B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		722E83F82BE735EA007163D4 /* CardStackView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardStackView.swift; sourceTree = "<group>"; };
@@ -378,6 +380,7 @@
 		722E844B2BE7365F007163D4 /* Protocol */ = {
 			isa = PBXGroup;
 			children = (
+				10D526262C2437EF004E66EA /* HashTagClientProtocol.swift */,
 				722E84482BE7365F007163D4 /* DeveloperClientProtocol.swift */,
 				722E84492BE7365F007163D4 /* ProductClientProtocol.swift */,
 				722E844A2BE7365F007163D4 /* ProductImageClientProtocol.swift */,
@@ -597,6 +600,7 @@
 				722E84702BE7365F007163D4 /* QRCodeRepository.swift in Sources */,
 				722E840D2BE735EA007163D4 /* MatchingViewModel.swift in Sources */,
 				72B3DB412BF2F928008BE7F9 /* HashTagView.swift in Sources */,
+				10D526272C2437F0004E66EA /* HashTagClientProtocol.swift in Sources */,
 				722E84752BE7365F007163D4 /* GetLoginDeveloperUseCase.swift in Sources */,
 				722E84732BE7365F007163D4 /* GetQRCodeUseCase.swift in Sources */,
 				722E84682BE7365F007163D4 /* Developer.swift in Sources */,

--- a/Gitagram.xcodeproj/project.pbxproj
+++ b/Gitagram.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		10472EEB2BDFAFBD00C179F8 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 10472EEA2BDFAFBD00C179F8 /* Assets.xcassets */; };
 		10472EEE2BDFAFBD00C179F8 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 10472EED2BDFAFBD00C179F8 /* Preview Assets.xcassets */; };
 		10502C6E2C1E850700097342 /* HashTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10502C6D2C1E850700097342 /* HashTag.swift */; };
+		10D526252C243731004E66EA /* HashTagResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10D526242C243726004E66EA /* HashTagResponse.swift */; };
 		23B6E52D2BE73C1D0049200B /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23B6E52C2BE73C1D0049200B /* ContentView.swift */; };
 		722E84052BE735EA007163D4 /* CardStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 722E83F82BE735EA007163D4 /* CardStackView.swift */; };
 		722E84062BE735EA007163D4 /* CardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 722E83F92BE735EA007163D4 /* CardView.swift */; };
@@ -95,6 +96,7 @@
 		10472EEA2BDFAFBD00C179F8 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		10472EED2BDFAFBD00C179F8 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		10502C6D2C1E850700097342 /* HashTag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HashTag.swift; sourceTree = "<group>"; };
+		10D526242C243726004E66EA /* HashTagResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HashTagResponse.swift; sourceTree = "<group>"; };
 		23B6E52C2BE73C1D0049200B /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		23B6E52E2BE7540F0049200B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		722E83F82BE735EA007163D4 /* CardStackView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardStackView.swift; sourceTree = "<group>"; };
@@ -182,6 +184,7 @@
 		10177A342BFA141600BA6078 /* Response */ = {
 			isa = PBXGroup;
 			children = (
+				10D526242C243726004E66EA /* HashTagResponse.swift */,
 				10177A352BFA148500BA6078 /* ProductResponse.swift */,
 				10177A372BFA3A4500BA6078 /* DeveloperResponse.swift */,
 			);
@@ -248,6 +251,13 @@
 				722E84042BE735EA007163D4 /* MatchingView */,
 			);
 			path = View;
+			sourceTree = "<group>";
+		};
+		10D526212C243693004E66EA /* HashTag */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = HashTag;
 			sourceTree = "<group>";
 		};
 		722E83FD2BE735EA007163D4 /* Component */ = {
@@ -332,6 +342,7 @@
 		722E843E2BE7365F007163D4 /* Client */ = {
 			isa = PBXGroup;
 			children = (
+				10D526212C243693004E66EA /* HashTag */,
 				722E843A2BE7365F007163D4 /* Developer */,
 				722E843D2BE7365F007163D4 /* Product */,
 			);
@@ -591,6 +602,7 @@
 				722E84682BE7365F007163D4 /* Developer.swift in Sources */,
 				722E84062BE735EA007163D4 /* CardView.swift in Sources */,
 				10261B052BE9427C007D1606 /* GradationBackView.swift in Sources */,
+				10D526252C243731004E66EA /* HashTagResponse.swift in Sources */,
 				722E846E2BE7365F007163D4 /* ProductClientProtocol.swift in Sources */,
 				722E847C2BE7365F007163D4 /* ProductRepositoryProtocol.swift in Sources */,
 				727952E92C1FF0B000788394 /* PickHashTagView.swift in Sources */,

--- a/Gitagram.xcodeproj/project.pbxproj
+++ b/Gitagram.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		10D526272C2437F0004E66EA /* HashTagClientProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10D526262C2437EF004E66EA /* HashTagClientProtocol.swift */; };
 		10D5262A2C243867004E66EA /* HashTagClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10D526292C243864004E66EA /* HashTagClient.swift */; };
 		10D5262C2C2439C1004E66EA /* HashTagRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10D5262B2C24398A004E66EA /* HashTagRepositoryProtocol.swift */; };
+		10D5262F2C243A2E004E66EA /* HashTagRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10D5262E2C243A28004E66EA /* HashTagRepository.swift */; };
 		23B6E52D2BE73C1D0049200B /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23B6E52C2BE73C1D0049200B /* ContentView.swift */; };
 		722E84052BE735EA007163D4 /* CardStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 722E83F82BE735EA007163D4 /* CardStackView.swift */; };
 		722E84062BE735EA007163D4 /* CardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 722E83F92BE735EA007163D4 /* CardView.swift */; };
@@ -103,6 +104,7 @@
 		10D526262C2437EF004E66EA /* HashTagClientProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HashTagClientProtocol.swift; sourceTree = "<group>"; };
 		10D526292C243864004E66EA /* HashTagClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HashTagClient.swift; sourceTree = "<group>"; };
 		10D5262B2C24398A004E66EA /* HashTagRepositoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HashTagRepositoryProtocol.swift; sourceTree = "<group>"; };
+		10D5262E2C243A28004E66EA /* HashTagRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HashTagRepository.swift; sourceTree = "<group>"; };
 		23B6E52C2BE73C1D0049200B /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		23B6E52E2BE7540F0049200B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		722E83F82BE735EA007163D4 /* CardStackView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardStackView.swift; sourceTree = "<group>"; };
@@ -267,6 +269,14 @@
 			path = HashTag;
 			sourceTree = "<group>";
 		};
+		10D5262D2C243A15004E66EA /* HashTag */ = {
+			isa = PBXGroup;
+			children = (
+				10D5262E2C243A28004E66EA /* HashTagRepository.swift */,
+			);
+			path = HashTag;
+			sourceTree = "<group>";
+		};
 		722E83FD2BE735EA007163D4 /* Component */ = {
 			isa = PBXGroup;
 			children = (
@@ -404,6 +414,7 @@
 		722E844F2BE7365F007163D4 /* Repository */ = {
 			isa = PBXGroup;
 			children = (
+				10D5262D2C243A15004E66EA /* HashTag */,
 				722E84442BE7365F007163D4 /* Developer */,
 				722E84472BE7365F007163D4 /* Product */,
 				722E844B2BE7365F007163D4 /* Protocol */,
@@ -640,6 +651,7 @@
 				722E84772BE7365F007163D4 /* GetProductListUseCase.swift in Sources */,
 				722E841B2BE7360C007163D4 /* InputFormView.swift in Sources */,
 				722E840B2BE735EA007163D4 /* SizeConstants.swift in Sources */,
+				10D5262F2C243A2E004E66EA /* HashTagRepository.swift in Sources */,
 				722E84082BE735EA007163D4 /* SwipeActionIndicatorView.swift in Sources */,
 				722E84162BE73601007163D4 /* PostImageView.swift in Sources */,
 				722E847F2BE7365F007163D4 /* UseCaseDI.swift in Sources */,

--- a/Gitagram/Model/Client/HashTag/HashTagClient.swift
+++ b/Gitagram/Model/Client/HashTag/HashTagClient.swift
@@ -35,4 +35,13 @@ class HashTagClient : HashTagClientProtocol {
         
         return nil
     }
+    
+    func create(hashtag: HashTagResponse) {
+        do {
+            try db.collection(COLLECTION).document(hashtag.id.uuidString).setData(from: hashtag)
+            print("Document successfully written!")
+        } catch {
+            print("Error writing document: \(error)")
+        }
+    }
 }

--- a/Gitagram/Model/Client/HashTag/HashTagClient.swift
+++ b/Gitagram/Model/Client/HashTag/HashTagClient.swift
@@ -36,9 +36,9 @@ class HashTagClient : HashTagClientProtocol {
         return nil
     }
     
-    func create(hashtag: HashTagResponse) {
+    func create(hashTag: HashTagResponse) {
         do {
-            try db.collection(COLLECTION).document(hashtag.id.uuidString).setData(from: hashtag)
+            try db.collection(COLLECTION).document(hashTag.id.uuidString).setData(from: hashTag)
             print("Document successfully written!")
         } catch {
             print("Error writing document: \(error)")

--- a/Gitagram/Model/Client/HashTag/HashTagClient.swift
+++ b/Gitagram/Model/Client/HashTag/HashTagClient.swift
@@ -1,0 +1,38 @@
+//
+//  HashTagClient.swift
+//  Gitagram
+//
+//  Created by 浦山秀斗 on 2024/06/20.
+//
+
+import Foundation
+import FirebaseFirestore
+
+class HashTagClient : HashTagClientProtocol {
+    private let db = Firestore.firestore()
+    private let COLLECTION = "tags"
+    
+    func getAll() async -> [HashTagResponse] {
+        let ref = db.collection(COLLECTION)
+        do {
+            return try await ref.getDocuments()
+                        .documents
+                        .compactMap { try? $0.data(as: HashTagResponse.self)}
+        } catch {
+            print("Error Writing Document: \(error)")
+        }
+        
+        return []
+    }
+    
+    func get(hashtag_id: UUID) async -> HashTagResponse? {
+        let docRef = db.collection(COLLECTION).document(hashtag_id.uuidString)
+        do {
+            return try await docRef.getDocument(as: HashTagResponse.self)
+        } catch {
+            print("Error decoding city: \(error)")
+        }
+        
+        return nil
+    }
+}

--- a/Gitagram/Model/Client/HashTag/TagProductClient.swift
+++ b/Gitagram/Model/Client/HashTag/TagProductClient.swift
@@ -16,7 +16,7 @@ public class TagProductClient : TagProductClientProtocol {
         let ref = db.collection(COLLECTION)
         
         do {
-            let query = ref.whereField("product_id", isEqualTo: product_id)
+            let query = ref.whereField("product_id", isEqualTo: product_id.uuidString)
             let snapshot = try await query.getDocuments()
             
             let tagIDs: [UUID] = snapshot.documents.compactMap { document in
@@ -38,7 +38,7 @@ public class TagProductClient : TagProductClientProtocol {
         let ref = db.collection(COLLECTION)
         
         do {
-            let query = ref.whereField("tag_id", isEqualTo: hashTag_id)
+            let query = ref.whereField("tag_id", isEqualTo: hashTag_id.uuidString)
             let snapshot = try await query.getDocuments()
             
             let productIDs: [UUID] = snapshot.documents.compactMap { document in
@@ -69,7 +69,7 @@ public class TagProductClient : TagProductClientProtocol {
     func deleteTag(from hashTag_id: UUID) {
         let ref = db.collection(COLLECTION)
         
-        let query = ref.whereField("tag_id", isEqualTo: hashTag_id)
+        let query = ref.whereField("tag_id", isEqualTo: hashTag_id.uuidString)
         query.getDocuments() { (querySnapshot, err) in
             guard (err != nil) else { return }
             for document in querySnapshot!.documents {
@@ -81,7 +81,7 @@ public class TagProductClient : TagProductClientProtocol {
     func deleteProduct(from product_id: UUID) {
         let ref = db.collection(COLLECTION)
         
-        let query = ref.whereField("product_id", isEqualTo: product_id)
+        let query = ref.whereField("product_id", isEqualTo: product_id.uuidString)
         query.getDocuments() { (querySnapshot, err) in
             guard (err != nil) else { return }
             for document in querySnapshot!.documents {

--- a/Gitagram/Model/Client/HashTag/TagProductClient.swift
+++ b/Gitagram/Model/Client/HashTag/TagProductClient.swift
@@ -1,0 +1,102 @@
+//
+//  TagProductClient.swift
+//  Gitagram
+//
+//  Created by 浦山秀斗 on 2024/06/20.
+//
+
+import Foundation
+import FirebaseFirestore
+
+public class TagProductClient : TagProductClientProtocol {
+    private let db = Firestore.firestore()
+    private let COLLECTION = "tag_product"
+    
+    func whereProduct(from product_id: UUID) async -> [UUID] {
+        let ref = db.collection(COLLECTION)
+        
+        do {
+            let query = ref.whereField("product_id", isEqualTo: product_id)
+            let snapshot = try await query.getDocuments()
+            
+            let tagIDs: [UUID] = snapshot.documents.compactMap { document in
+                if let tagID = document.data()["tag_id"] as? String {
+                    return UUID(uuidString: tagID)!
+                }
+                return nil
+            }
+            
+            return tagIDs
+        } catch {
+            print("Error: whereProduct")
+        }
+        
+        return []
+    }
+    
+    func whereTag(from hashTag_id: UUID) async -> [UUID] {
+        let ref = db.collection(COLLECTION)
+        
+        do {
+            let query = ref.whereField("tag_id", isEqualTo: hashTag_id)
+            let snapshot = try await query.getDocuments()
+            
+            let productIDs: [UUID] = snapshot.documents.compactMap { document in
+                if let productID = document.data()["product_id"] as? String {
+                    return UUID(uuidString: productID)!
+                }
+                return nil
+            }
+            
+            return productIDs
+        } catch {
+            print("Error: whereTag")
+        }
+        
+        return []
+    }
+    
+    func createTagProduct(hashTag: UUID, product: UUID) {
+        do {
+            let hashTagProduct = HashTagProduct(product_id: product, tag_id: hashTag)
+            try db.collection(COLLECTION).document().setData(from: hashTagProduct)
+            print("Document successfully written!")
+        } catch {
+            print("Error writing document: \(error)")
+        }
+    }
+    
+    func deleteTag(from hashTag_id: UUID) {
+        let ref = db.collection(COLLECTION)
+        
+        let query = ref.whereField("tag_id", isEqualTo: hashTag_id)
+        query.getDocuments() { (querySnapshot, err) in
+            guard (err != nil) else { return }
+            for document in querySnapshot!.documents {
+              document.reference.delete()
+            }
+        }
+    }
+    
+    func deleteProduct(from product_id: UUID) {
+        let ref = db.collection(COLLECTION)
+        
+        let query = ref.whereField("product_id", isEqualTo: product_id)
+        query.getDocuments() { (querySnapshot, err) in
+            guard (err != nil) else { return }
+            for document in querySnapshot!.documents {
+              document.reference.delete()
+            }
+        }
+    }
+    
+    struct HashTagProduct : Codable {
+        let product_id: UUID
+        let tag_id: UUID
+        
+        init(product_id: UUID, tag_id: UUID) {
+            self.product_id = product_id
+            self.tag_id = tag_id
+        }
+    }
+}

--- a/Gitagram/Model/DataModel/Response/HashTagResponse.swift
+++ b/Gitagram/Model/DataModel/Response/HashTagResponse.swift
@@ -1,0 +1,24 @@
+//
+//  HashTagResponse.swift
+//  Gitagram
+//
+//  Created by 浦山秀斗 on 2024/06/20.
+//
+
+import Foundation
+
+struct HashTagResponse : Identifiable, Codable {
+    let id: UUID
+    let name: String
+    let color: String
+        
+    init(from hashTag: HashTag) {
+        self.id = hashTag.id.toUUID
+        self.name = hashTag.name
+        self.color = hashTag.color
+    }
+    
+    func toHashTag() -> HashTag {
+        return HashTag(id: HashTag.HashTagID(id: id), name: name, color: color)
+    }
+}

--- a/Gitagram/Model/Repository/HashTag/HashTagRepository.swift
+++ b/Gitagram/Model/Repository/HashTag/HashTagRepository.swift
@@ -1,0 +1,15 @@
+//
+//  HashTagRepository.swift
+//  Gitagram
+//
+//  Created by 浦山秀斗 on 2024/06/20.
+//
+
+class HashTagRepository : HashTagRepositoryProtocol {
+    private let hashTagClient = RepositoryDI.hashTagClient
+    
+    func getAll() async -> [HashTag] {
+        let response = await hashTagClient.getAll()
+        return response.map { $0.toHashTag() }
+    }
+}

--- a/Gitagram/Model/Repository/Product/ProductRepository.swift
+++ b/Gitagram/Model/Repository/Product/ProductRepository.swift
@@ -9,22 +9,39 @@ import Foundation
 
 class ProductRepository : ProductRepositoryProtocol {
     private let repositoryClient = RepositoryDI.productClient
+    private let tagClient = RepositoryDI.hashTagClient
+    private let tagProductClient = RepositoryDI.tagProductClient
     
     func getAll() async -> [Product] {
-        await repositoryClient.getAll().map { product in
+        let products = await repositoryClient.getAll().map { product in
             return product.toProduct()
         }
+        
+        let attachedTagProducts = await attachTags(to: products)
+        
+        return attachedTagProducts
     }
     
     func create(object: Product) {
         repositoryClient.create(product: ProductResponse(from: object))
+        
+        if object.hashTags.isEmpty { return }
+        
+        for hashTag in object.hashTags {
+            if hashTag.isEmpty() { continue }
+            let tagID = hashTag.id.toUUID
+            let productID = object.id.toUUID
+            tagProductClient.createTagProduct(hashTag: tagID, product: productID)
+        }
     }
     
     func get(id: Product.ID) async -> Product? {
-        if let response = await repositoryClient.get(product_id: id.toUUID) {
-            return response.toProduct()
-        }
-        return nil
+        guard let response = await repositoryClient.get(product_id: id.toUUID) else { return nil }
+        
+        let product = response.toProduct()
+        let attachedTagProduct = await attachTag(to: product)
+        
+        return attachedTagProduct
     }
     
     func update(id: Product.ID, with newProduct: Product) {
@@ -33,5 +50,38 @@ class ProductRepository : ProductRepositoryProtocol {
     
     func delete(id: Product.ID) {
         repositoryClient.delete(product_id: id.toUUID)
+        tagProductClient.deleteProduct(from: id.toUUID)
+    }
+    
+    private func attachTags(to products: [Product]) async -> [Product] {
+        return await products.asyncMap { product in
+            return await attachTag(to: product)
+        }
+    }
+    
+    private func attachTag(to product: Product) async -> Product {
+        var attachedTagProduct = product
+        let hashTagIDs = await tagProductClient.whereProduct(from: product.id.toUUID)
+        
+        for tagId in hashTagIDs {
+            guard let hashTagResponse = await tagClient.get(hashtag_id: tagId) else { continue }
+           
+            attachedTagProduct = attachedTagProduct.addHashTag(from: hashTagResponse.toHashTag())
+        }
+        
+        return attachedTagProduct
+    }
+}
+
+extension Sequence {
+    func asyncMap<T>(
+        _ closure: @Sendable (Element) async throws -> T
+    ) async rethrows -> [T] {
+        var array: [T] = []
+        array.reserveCapacity(self.underestimatedCount)
+        for element in self {
+            array.append(try await closure(element))
+        }
+        return array
     }
 }

--- a/Gitagram/Model/Repository/Protocol/HashTagClientProtocol.swift
+++ b/Gitagram/Model/Repository/Protocol/HashTagClientProtocol.swift
@@ -10,4 +10,5 @@ import Foundation
 protocol HashTagClientProtocol {
     func getAll() async -> [HashTagResponse]
     func get(hashtag_id: UUID) async -> HashTagResponse?
+    func create(hashTag: HashTagResponse)
 }

--- a/Gitagram/Model/Repository/Protocol/HashTagClientProtocol.swift
+++ b/Gitagram/Model/Repository/Protocol/HashTagClientProtocol.swift
@@ -1,0 +1,13 @@
+//
+//  HashTagClientProtocol.swift
+//  Gitagram
+//
+//  Created by 浦山秀斗 on 2024/06/20.
+//
+
+import Foundation
+
+protocol HashTagClientProtocol {
+    func getAll() async -> [HashTagResponse]
+    func get(hashtag_id: UUID) async -> HashTagResponse?
+}

--- a/Gitagram/Model/Repository/RepositoryDI.swift
+++ b/Gitagram/Model/Repository/RepositoryDI.swift
@@ -12,4 +12,5 @@ class RepositoryDI {
     public static let productClient = ProductClient()
     public static let productImageClient = ProductImageClient()
     public static let hashTagClient = HashTagClient()
+    public static let tagProductClient = TagProductClient()
 }

--- a/Gitagram/Model/Repository/RepositoryDI.swift
+++ b/Gitagram/Model/Repository/RepositoryDI.swift
@@ -11,4 +11,5 @@ class RepositoryDI {
     public static let developerClient = DeveloperClient()
     public static let productClient = ProductClient()
     public static let productImageClient = ProductImageClient()
+    public static let hashTagClient = HashTagClient()
 }

--- a/Gitagram/Model/UseCase/Product/GetProductImageUseCase.swift
+++ b/Gitagram/Model/UseCase/Product/GetProductImageUseCase.swift
@@ -12,7 +12,7 @@ class GetProductImageUseCase {
     let productImageRepository = UseCaseDI.productImageRepository
     
     func execute(id: Product.ID) async -> UIImage? {
-     let image =  await productImageRepository.fetchImage(id: id)
-              return image
+        let image = await productImageRepository.fetchImage(id: id)
+        return image
     }
 }

--- a/Gitagram/Model/UseCase/Protocol/HashTagProductClientProtocol.swift
+++ b/Gitagram/Model/UseCase/Protocol/HashTagProductClientProtocol.swift
@@ -1,0 +1,16 @@
+//
+//  HashTagProductClientProtocol.swift
+//  Gitagram
+//
+//  Created by 浦山秀斗 on 2024/06/20.
+//
+
+import Foundation
+
+protocol TagProductClientProtocol {
+    func whereProduct(from product_id: UUID) async -> [UUID]
+    func whereTag(from hashTag_id: UUID) async -> [UUID]
+    func createTagProduct(hashTag: UUID, product: UUID)
+    func deleteTag(from hashTag_id: UUID)
+    func deleteProduct(from product_id: UUID)
+}

--- a/Gitagram/Model/UseCase/Protocol/HashTagRepositoryProtocol.swift
+++ b/Gitagram/Model/UseCase/Protocol/HashTagRepositoryProtocol.swift
@@ -1,0 +1,10 @@
+//
+//  Untitled.swift
+//  Gitagram
+//
+//  Created by 浦山秀斗 on 2024/06/20.
+//
+
+protocol HashTagRepositoryProtocol {
+    func getAll() async -> [HashTag]
+}

--- a/Gitagram/Model/UseCase/UseCaseDI.swift
+++ b/Gitagram/Model/UseCase/UseCaseDI.swift
@@ -12,4 +12,5 @@ class UseCaseDI {
     static let productRepository: ProductRepositoryProtocol = ProductRepository()
     static let productImageRepository = ProductImageRepository()
     static let qrRepository: QRCodeProtocol = QRCodeRepository()
+    static let hashTagRepository: HashTagRepositoryProtocol = HashTagRepository()
 }


### PR DESCRIPTION
## やったこと
- HashTagに必要な機能のみの実装(CRUD)
- Client ~ Repository層までの実装。
- **_UseCase以下の振る舞いは一切変わってない。_**

## 影響範囲
- Client ~ Repository(Product, HashTag)

## 補足
- UI適用は別PRにて実装する。

## スクリーンショット
今回はなし。

## 動作確認
- Firebaseの"tags", "tagproduct" テーブルからデータを読み込み、取得ができている。

close #
