### PR TITLE
Productのハッシュタグの表示UI(MatchingView)

### DIFF
--- a/Gitagram/Model/DataModel/Entity/HashTag.swift
+++ b/Gitagram/Model/DataModel/Entity/HashTag.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct HashTag : Identifiable {
+struct HashTag : Identifiable, Hashable {
     typealias HashTagID = HashTag.ID
     
     var id : HashTagID

--- a/Gitagram/View/MatchingView/Component/CardView.swift
+++ b/Gitagram/View/MatchingView/Component/CardView.swift
@@ -31,14 +31,17 @@ struct CardView: View {
                 SwipeActionIndicatorView(xofset: $xoffset)
             }
             VStack(alignment: .leading){
-                
                 UserInfoView(cardData: cardData)
-                HStack(){
-                    HashTagView(tagWord: .constant("swift"))
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 10) {
+                        ForEach(cardData.product.hashTags, id: \.self) { hashTag in
+                            HashTagView(hashTag: hashTag)
+                        }
+                    }
+                    .padding(.horizontal, 15)
+                    .padding(.bottom, 15)
                 }
-                .padding(.leading, 15)
-                .padding(.bottom, 15)
-                .frame(alignment: .leading)
+                .frame(maxHeight: 40)
             }
             .background(
                 LinearGradient(colors: [.clear,.black], startPoint: .top , endPoint: .bottom)

--- a/Gitagram/View/MatchingView/Component/HashTagView.swift
+++ b/Gitagram/View/MatchingView/Component/HashTagView.swift
@@ -8,23 +8,24 @@
 import SwiftUI
 
 struct HashTagView: View {
-    @Binding var tagWord :String
+    let hashTag :HashTag
+    
+    var color: UIColor {
+        UIColor(hex: hashTag.color) ?? UIColor.white
+    }
     
     var body: some View {
         HStack{
             Text("#")
-            Text(tagWord)
+            Text(hashTag.name)
         }
         .padding(4)
         .padding(.horizontal, 5)
-        
-        .background(Color(Color(red: 0.82, green: 0.6, blue: 0.97)))
+        .background(Color(uiColor: color))
         .cornerRadius(50)
-       
     }
-    
 }
 
 #Preview {
-    HashTagView(tagWord: .constant("swift"))
+    HashTagView(hashTag: .Empty())
 }


### PR DESCRIPTION
## やったこと
- 各Productの持っているハッシュタグを表示できるようにした。
- HashTagをHashableに準拠させた

## 影響範囲
- CardView
- HashTag
- HashTagView

## スクリーンショット
| ハッシュタグなし | ハッシュタグあり |
|--------|--------|
| <img width="323" alt="スクリーンショット 2024-06-30 18 52 54" src="https://github.com/ProgateHackathon/Gitagram/assets/84073765/1fc3b027-41c6-4e75-97bd-faf74d2b27a0"> | <img width="317" alt="スクリーンショット 2024-06-30 18 54 29" src="https://github.com/ProgateHackathon/Gitagram/assets/84073765/101c063a-3f4c-4099-b201-9ef7e8e3e0c0"> | 

## 動作確認
- iOS18 simulatorにて動作確認済み

close #
