### PR TITLE
ハッシュタグフィルター機能実装

### DIFF
--- a/Gitagram/View/MatchingView/Component/CardStackView.swift
+++ b/Gitagram/View/MatchingView/Component/CardStackView.swift
@@ -21,7 +21,8 @@ struct CardStackView: View {
                     Text("全部見終わったよ！\n左上のリロードボタンを押してね！")
                 }
                 
-                ForEach(viewModel.repositories){ repository in
+                ForEach(viewModel.filterdRepository()){ repository in
+                    
                     CardView(viewModel: viewModel, isShowAlert: $isShowAlert, cardData: repository)
                 }
             }

--- a/Gitagram/View/MatchingView/Component/PickHashTagView.swift
+++ b/Gitagram/View/MatchingView/Component/PickHashTagView.swift
@@ -22,7 +22,7 @@ struct PickHashTagView: View {
         }
     }
     @Environment(\.dismiss) private var dismiss
-    @State var tapTag = ""
+    @Binding var pickHashTag: HashTag
     
     var body: some View {
         NavigationView {
@@ -39,7 +39,7 @@ struct PickHashTagView: View {
                                     .foregroundColor(.black)
                                     .padding()
                                     .onTapGesture {
-                                        tapTag = hashTag.name
+                                        pickHashTag = hashTag
                                         dismiss()
                                     }
                             }
@@ -64,6 +64,6 @@ struct PickHashTagView: View {
 }
 
 #Preview {
-    PickHashTagView()
+    PickHashTagView(pickHashTag: .constant(.Empty()))
 }
 

--- a/Gitagram/View/MatchingView/MatchingView.swift
+++ b/Gitagram/View/MatchingView/MatchingView.swift
@@ -62,9 +62,7 @@ struct MatchingView: View {
         }
         .onAppear(){
             Task {
-                if let host =  await GetLoginDeveloperUseCase().execute() {
-                    viewModel.loginHost = host
-                }
+                await viewModel.getLoginHost()
                 await viewModel.getRepository()
             }
         }

--- a/Gitagram/View/MatchingView/MatchingView.swift
+++ b/Gitagram/View/MatchingView/MatchingView.swift
@@ -60,12 +60,6 @@ struct MatchingView: View {
                 .presentationBackground(.ultraThinMaterial)
                 .presentationDetents([.medium])
         }
-        .onAppear(){
-            Task {
-                await viewModel.getLoginHost()
-                await viewModel.getRepository()
-            }
-        }
     }
 }
 

--- a/Gitagram/View/MatchingView/MatchingView.swift
+++ b/Gitagram/View/MatchingView/MatchingView.swift
@@ -9,8 +9,9 @@ import SwiftUI
 
 struct MatchingView: View {
     @State var showAddRepository = false
+    @State var showHashTagSheet = false
     @ObservedObject var viewModel = MatchingViewModel()
-    @State var pickHashTag = false
+    @State var pickHashTag: HashTag = .Empty()
     @State var loginHost: Developer = .Empty()
     
     var body: some View {
@@ -22,7 +23,6 @@ struct MatchingView: View {
                 VStack{
                     CardStackView(viewModel: viewModel)
                         .toolbar {
-                            
                             ToolbarItem(placement: .navigationBarTrailing) {
                                 Button {
                                     showAddRepository.toggle()
@@ -41,10 +41,15 @@ struct MatchingView: View {
                             }
                             ToolbarItem(placement: .navigationBarLeading) {
                                 Button {
-                                    pickHashTag = true
+                                    showHashTagSheet = true
                                 } label:{
                                     Image(systemName: "tag")
                                     
+                                }
+                            }
+                            ToolbarItem(placement: .principal) {
+                                if (!pickHashTag.isEmpty()) {
+                                    HashTagView(hashTag: pickHashTag)
                                 }
                             }
                         }
@@ -54,8 +59,8 @@ struct MatchingView: View {
         .sheet(isPresented: $showAddRepository) {
             PostView()
         }
-        .sheet(isPresented: $pickHashTag) {
-            PickHashTagView()
+        .sheet(isPresented: $showHashTagSheet) {
+            PickHashTagView(pickHashTag: $pickHashTag)
                 .presentationBackground(.ultraThinMaterial)
                 .presentationDetents([.medium])
         }

--- a/Gitagram/View/MatchingView/MatchingView.swift
+++ b/Gitagram/View/MatchingView/MatchingView.swift
@@ -8,11 +8,7 @@
 import SwiftUI
 
 struct MatchingView: View {
-    @State var showAddRepository = false
-    @State var showHashTagSheet = false
     @ObservedObject var viewModel = MatchingViewModel()
-    @State var pickHashTag: HashTag = .Empty()
-    @State var loginHost: Developer = .Empty()
     
     var body: some View {
         NavigationView {
@@ -25,7 +21,7 @@ struct MatchingView: View {
                         .toolbar {
                             ToolbarItem(placement: .navigationBarTrailing) {
                                 Button {
-                                    showAddRepository.toggle()
+                                    viewModel.showAddRepository.toggle()
                                 } label: {
                                     Image(systemName: "plus.circle")
                                 }
@@ -41,33 +37,33 @@ struct MatchingView: View {
                             }
                             ToolbarItem(placement: .navigationBarLeading) {
                                 Button {
-                                    showHashTagSheet = true
+                                    viewModel.showHashTagSheet = true
                                 } label:{
                                     Image(systemName: "tag")
                                     
                                 }
                             }
                             ToolbarItem(placement: .principal) {
-                                if (!pickHashTag.isEmpty()) {
-                                    HashTagView(hashTag: pickHashTag)
+                                if (!viewModel.pickHashTag.isEmpty()) {
+                                    HashTagView(hashTag: viewModel.pickHashTag)
                                 }
                             }
                         }
                 }
             }
         }
-        .sheet(isPresented: $showAddRepository) {
+        .sheet(isPresented: $viewModel.showAddRepository) {
             PostView()
         }
-        .sheet(isPresented: $showHashTagSheet) {
-            PickHashTagView(pickHashTag: $pickHashTag)
+        .sheet(isPresented: $viewModel.showHashTagSheet) {
+            PickHashTagView(pickHashTag: $viewModel.pickHashTag)
                 .presentationBackground(.ultraThinMaterial)
                 .presentationDetents([.medium])
         }
         .onAppear(){
             Task {
                 if let host =  await GetLoginDeveloperUseCase().execute() {
-                    loginHost = host
+                    viewModel.loginHost = host
                 }
                 await viewModel.getRepository()
             }
@@ -76,7 +72,7 @@ struct MatchingView: View {
 }
 
 #Preview {
-    MatchingView(loginHost: .Empty())
+    MatchingView()
 }
 
 

--- a/Gitagram/View/MatchingView/MatchingViewModel.swift
+++ b/Gitagram/View/MatchingView/MatchingViewModel.swift
@@ -40,6 +40,12 @@ class MatchingViewModel: ObservableObject {
         isLoading = false
     }
     
+    public func getLoginHost() async {
+        if let host =  await GetLoginDeveloperUseCase().execute() {
+            loginHost = host
+        }
+    }
+    
     private func fetchCardInfomation() async -> [CardData] {
         var cardList = [CardData]()
         let products = await GetProductListUseCase().execute()

--- a/Gitagram/View/MatchingView/MatchingViewModel.swift
+++ b/Gitagram/View/MatchingView/MatchingViewModel.swift
@@ -13,6 +13,10 @@ class MatchingViewModel: ObservableObject {
     @Published var isLoading = true
     @Published var repositories: [CardData] = []
     @Published var buttonSwipeAction: SwipeAction?
+    @Published var showAddRepository = false
+    @Published var showHashTagSheet = false
+    @Published var pickHashTag: HashTag = .Empty()
+    @Published var loginHost: Developer = .Empty()
 
     func removeCard(_  product: Product){
         Task{


### PR DESCRIPTION
## やったこと
-  ハッシュタグのフィルター機能実装
- MatchingViewの状態管理をViewModelに持たせた。
- OnAppearだとTabBarで戻るたびに更新処理かかるのは体験が良くないので、ViewModelのinitにした。
- MatchingViewでhostの取得は使っていなかったので削除

## 影響範囲
- MatchingView
- MatchingViewModel
- PichHashTagView

## 補足

## スクリーンショット
<img width="410" alt="スクリーンショット 2024-07-03 15 52 54" src="https://github.com/ProgateHackathon/Gitagram/assets/84073765/d74cd8b4-32be-4ed3-b98f-1f56399bb09b">


## 動作確認
- ios18 simulator

close #
