### PR TITLE
nameからDeveloperを取ってこれるようにした。

### DIFF
--- a/Gitagram/Model/Client/Developer/DeveloperClient.swift
+++ b/Gitagram/Model/Client/Developer/DeveloperClient.swift
@@ -31,4 +31,18 @@ class DeveloperClient : DeveloperClientProtocol {
         
         return nil
     }
+    
+    func get(name: String) async -> DeveloperResponse? {
+        let query = db.collection(COLLECTION).whereField("name", isEqualTo: name)
+        do {
+            let snapshot = try await query.getDocuments()
+            if let document = snapshot.documents.first {
+                return try document.data(as: DeveloperResponse.self)
+            }
+        } catch {
+            print("Error decoding developer: \(error)")
+        }
+        
+        return nil
+    }
 }

--- a/Gitagram/Model/Repository/Developer/DeveloperRepository.swift
+++ b/Gitagram/Model/Repository/Developer/DeveloperRepository.swift
@@ -25,6 +25,14 @@ class DeveloperRepository : DeveloperRepositoryProtocol {
         return nil
     }
     
+    func get(name: String) async -> Developer? {
+        if let response = await developerClient.get(name: name) {
+            return response.toDeveloper()
+        }
+        
+        return nil
+    }
+    
     func getLoginDeveloper() async -> Developer? {
         guard let uuidString = UserDefaults.standard.string(forKey: SIGNIN_DEVELOPER_KEY) else { return nil }
         guard let uuid = UUID(uuidString: uuidString) else {

--- a/Gitagram/Model/Repository/Protocol/DeveloperClientProtocol.swift
+++ b/Gitagram/Model/Repository/Protocol/DeveloperClientProtocol.swift
@@ -10,4 +10,5 @@ import Foundation
 protocol DeveloperClientProtocol {
     func create(developer: DeveloperResponse) async
     func get(developer_id: UUID) async -> DeveloperResponse?
+    func get(name: String) async -> DeveloperResponse?
 }

--- a/Gitagram/Model/UseCase/Developer/GetDeveloperUseCase.swift
+++ b/Gitagram/Model/UseCase/Developer/GetDeveloperUseCase.swift
@@ -13,4 +13,8 @@ class GetDeveloperUseCase {
     func execute(id: Developer.ID) async -> Developer? {
         await developerRepository.get(id: id)
     }
+    
+    func execute(username: String) async -> Developer? {
+        await developerRepository.get(name: username)
+    }
 }

--- a/Gitagram/Model/UseCase/Protocol/DeveloperRepositoryProtocol.swift
+++ b/Gitagram/Model/UseCase/Protocol/DeveloperRepositoryProtocol.swift
@@ -10,6 +10,7 @@ import Foundation
 protocol DeveloperRepositoryProtocol {
     func create(object: Developer) async
     func get(id: Developer.ID) async -> Developer?
+    func get(name: String) async -> Developer?
     func getLoginDeveloper() async -> Developer?
     func update(id: Developer.ID, with newDeveloper: Developer) async
     func delete(id: Developer.ID) async


### PR DESCRIPTION
## 背景
同じ名前のDeveloper多すぎ問題...
<img width="751" alt="スクリーンショット 2024-07-09 13 51 46" src="https://github.com/ProgateHackathon/Gitagram/assets/84073765/9650df34-ad3e-45f4-950b-497bb477e02a">

## やったこと
- Client : get(name: String) を新たに実装
- Repository : get(name: String) を新たに実装
- GetDeveloperUseCase : execute(name: String) を新たに実装

## 影響範囲

## 使い方
```swift
let developer = await GetDeveloperUseCase().execute(username: username)
```

## 補足
- 名前が複数ある場合は最初に取得したものが呼ばれている。


## スクリーンショット

## 動作確認

close #
