### PR TITLE
選択した画像を設定できるようにした

### DIFF
--- a/Gitagram/View/PostView/PostImageView.swift
+++ b/Gitagram/View/PostView/PostImageView.swift
@@ -4,50 +4,58 @@
 //
 //  Created by saki on 2024/05/04.
 //
-
 import SwiftUI
 import PhotosUI
 
 struct PostImageView: View {
     @EnvironmentObject var postViewModel: PostViewModel
-    @State var showImagePicker = false
-    @State var selectedPhoto: PhotosPickerItem?
+    @State private var showImagePicker = false
+    @State private var selectedPhoto: PhotosPickerItem?
     @Environment(\.dismiss) private var dismiss
-    @State var selectImage: Image? = nil
+    @State private var selectImage: Image? = nil
+    @State private var showColorPicker = false
+    @State private var selectedColor: Color = Color(.sRGB, red: 0.98, green: 0.9, blue: 0.2)
     
     var body: some View {
-        VStack{
-            Text("リポジトリの画像を貼ろう")
+        VStack {
+            Text("リポジトリのイメージは??")
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.leading,10)
+                .padding(.leading, 10)
                 .font(.system(size: 30, weight: .black, design: .default))
-                .padding(.bottom,30)
-            
-            Spacer()
             
             if let image = selectImage {
                 image
                     .resizable()
                     .scaledToFit()
-                    .frame(width: 300, height: 300)
+                    .frame(width: 280, height: 280)
                     .cornerRadius(15)
                     .padding()
-                
+            } else {
+                RoundedRectangle(cornerSize: CGSize(width: 15, height: 15))
+                    .foregroundStyle(selectedColor)
+                    .frame(width: 280, height: 280)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 15)
+                            .stroke(Color(.sRGB, red: 1.0, green: 1.0, blue: 1.0, opacity: 0.4), lineWidth: 7)
+                    )
+                    .padding()
             }
             
-            PhotosPicker(selection: $selectedPhoto,matching: .images){
-                HStack{
+            Spacer()
+            
+            PhotosPicker(selection: $selectedPhoto, matching: .images) {
+                HStack {
                     Image(systemName: "photo.badge.plus")
                     Text("画像のアップロード")
                 }
-                .padding(.horizontal,40)
-                .padding(.vertical,15)
+                .frame(width: 280)
+                .padding(.vertical, 15)
                 .foregroundColor(.black)
                 .background(Color.white)
                 .cornerRadius(35)
                 .overlay(
                     RoundedRectangle(cornerRadius: 30)
-                        .stroke(Color(Color(red: 0.82, green: 0.6, blue: 0.97)), lineWidth: 3)
+                        .stroke(Color(red: 0.82, green: 0.6, blue: 0.97), lineWidth: 3)
                 )
             }
             .onChange(of: selectedPhoto) {
@@ -57,40 +65,66 @@ struct PostImageView: View {
                     postViewModel.setImage(image: loadedImage ?? postViewModel.cardData.productImage)
                 }
             }
+            .padding(.bottom, 20)
             
-            .padding(.bottom,20)
+            HStack {
+                ColorPicker(selection: $selectedColor) {
+                }
+                .labelsHidden()
+                
+                Text("色を設定する")
+            }
+                .frame(width: 280)
+                .padding(.vertical, 10)
+                .foregroundColor(.black)
+                .background(Color.white)
+                .cornerRadius(35)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 30)
+                        .stroke(Color(red: 0.82, green: 0.6, blue: 0.97), lineWidth: 3)
+                )
+                .padding(.bottom, 20)
             
             Button(action: {
+                if selectImage == nil {
+                    let rectangleView = Rectangle()
+                                            .foregroundStyle(selectedColor)
+                                            .frame(width: 280, height: 280)
+                                        
+                    if let image = postViewModel.convertViewToImage(from: rectangleView) {
+                        postViewModel.setImage(image: image)
+                    }
+                }
+                
                 Task {
                     if postViewModel.cardData.isComplete() {
                         await PostProductUseCase().execute(product: postViewModel.cardData.product, productImage: postViewModel.cardData.productImage)
                     }
                 }
                 
-                UIApplication.shared.windows.first{ $0.isKeyWindow }?.rootViewController?.dismiss(animated: true, completion: nil)
-            }, label: {
+                UIApplication.shared.windows.first { $0.isKeyWindow }?.rootViewController?.dismiss(animated: true, completion: nil)
+            }) {
                 Text("保存")
-                    .padding(.horizontal,120)
-                    .padding(.vertical,15)
+                    .padding(.horizontal, 120)
+                    .padding(.vertical, 15)
                     .font(.system(size: 10, weight: .medium, design: .default))
                     .foregroundColor(.white)
-                    .background(Color(Color(red: 0.82, green: 0.6, blue: 0.97)))
+                    .background(Color(red: 0.82, green: 0.6, blue: 0.97))
                     .cornerRadius(30)
-                    .padding(.bottom,20)
-            })
+                    .padding(.bottom, 20)
+            }
         }
-        
     }
     
     private func loadImageFromSelectedPhoto(photo: PhotosPickerItem) async -> UIImage? {
         if let data = try? await photo.loadTransferable(type: Data.self) {
             return UIImage(data: data)
         }
-        
         return nil
     }
 }
 
 #Preview {
     PostImageView()
+        .environmentObject(PostViewModel())
 }

--- a/Gitagram/View/PostView/PostViewModel.swift
+++ b/Gitagram/View/PostView/PostViewModel.swift
@@ -7,24 +7,30 @@
 
 import Foundation
 import SwiftUI
+
+@MainActor
 class PostViewModel: ObservableObject {
     @Published var cardData: CardData = .Empty()
+    @Environment(\.displayScale) private var displayScale
     
     func setContent(content: Product){
         cardData = cardData.setProduct(from: content)
     }
+    
     func setTitle(title: String) -> Product{
         return cardData.product.setTitle(from: title)
     }
+    
     func setDesctiption(description: String) -> Product{
         return cardData.product.setContent(from: description)
     }
+    
     func setDeveloper(developer: String) -> Product{
         let developerName = cardData.loginHost.name
         let developer = Developer(githubId: developerName)
         return cardData.product.setDeveloper(from: developer)
-        
     }
+    
     func setURLTitle(title: String) -> Product{
         return  cardData.product.setTitle(from: title)
     }
@@ -32,6 +38,7 @@ class PostViewModel: ObservableObject {
     func setHashTag(hashTag: [HashTag]) -> Product{
         return  cardData.product.setHashTag(from: hashTag)
     }
+    
     func setImage(image: UIImage){
         cardData = cardData.setImage(from: image)
     }
@@ -39,5 +46,8 @@ class PostViewModel: ObservableObject {
         cardData = cardData.setLoginHost(from: host)
     }
     
-    
+    func convertViewToImage<Content: View>(from view: Content) -> UIImage? {
+        let renderer = ImageRenderer(content: view)
+        return renderer.uiImage
+    }
 }


### PR DESCRIPTION
## やったこと
- 選択した画像を設定できるようにした。
- color pickerの実装
- 設定後の下に黒が入り込むのが気になるけど、後回しにしたい(リリース後修正でも良いくらい)

## 影響範囲
- PostImageView
- PostViewModel

## 補足
- 特になし。

## スクリーンショット
<img width="200" alt="スクリーンショット 2024-07-15 10 39 38" src="https://github.com/user-attachments/assets/cfad17e3-7e27-4565-9e51-053144f56a14">
<img width="200" alt="スクリーンショット 2024-07-15 10 39 27" src="https://github.com/user-attachments/assets/ce852096-0784-4482-8ede-effffd35d462">


## 動作確認
- ios18にてビルド確認

close #
